### PR TITLE
Compatibility with PHP 8

### DIFF
--- a/src/Quip.php
+++ b/src/Quip.php
@@ -33,7 +33,7 @@ class Quip {
    * @return \QuipXml\Xml\QuipXmlElement
    */
   static public function load($source, $options = 0, $data_is_url = FALSE, $ns = '', $is_prefix = FALSE, $quip_options = 0) {
-    set_error_handler(function ($errno, $errstr, $errfile, $errline, $errcontext) {
+    set_error_handler(function ($errno, $errstr, $errfile, $errline) {
       throw new \ErrorException($errstr, $errno);
     }, E_WARNING);
     $error_reporting_level = error_reporting();


### PR DESCRIPTION
https://www.php.net/manual/en/function.set-error-handler.php

> errcontext
> This parameter has been DEPRECATED as of PHP 7.2.0, and REMOVED as of PHP 8.0.0. If the function defines this parameter without a default, an error of "too few arguments" will be raised when it is called.
